### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/zardvirtuallap/b5ab70ce-c31a-43a1-992f-0dafd098002e/8cdb10de-8c52-4b17-a590-84f4e35d2ba6/_apis/work/boardbadge/f66c20ea-9347-49b5-8bce-52373f6e2c08)](https://dev.azure.com/zardvirtuallap/b5ab70ce-c31a-43a1-992f-0dafd098002e/_boards/board/t/8cdb10de-8c52-4b17-a590-84f4e35d2ba6/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/zardvirtuallap/b5ab70ce-c31a-43a1-992f-0dafd098002e/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.